### PR TITLE
Fix markdown import collections

### DIFF
--- a/src/components/MediaImportExport.tsx
+++ b/src/components/MediaImportExport.tsx
@@ -154,7 +154,7 @@ export const MediaImportExport = () => {
       
       let currentCollectionId: string | null = null;
       let currentSection: 'collections' | 'movies' | null = null;
-      let mediaItems: Media[] = [...allMedia];
+      const mediaItems: Media[] = [...allMedia];
       const mediaMap = new Map(mediaItems.map(item => [item.title, item]));
       const collectionsCreated: Collection[] = [];
       
@@ -180,11 +180,17 @@ export const MediaImportExport = () => {
           
           // Check if collection already exists
           if (!collections.some(c => c.id === collectionId)) {
-            currentCollectionId = createCollection(collectionName);
-            
-            const newCollection = collections.find(c => c.id === currentCollectionId);
-            if (newCollection) {
-              collectionsCreated.push(newCollection);
+            const createdId = await createCollection(collectionName);
+
+            if (createdId) {
+              currentCollectionId = createdId;
+              collectionsCreated.push({
+                id: createdId,
+                name: collectionName,
+                mediaIds: [],
+              });
+            } else {
+              currentCollectionId = collectionId;
             }
           } else {
             currentCollectionId = collectionId;


### PR DESCRIPTION
## Summary
- fix awaiting createCollection in the markdown import logic to avoid storing a Promise in state
- mark imported media array as const

## Testing
- `npm run lint` *(fails: 10 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6863a3abeb4083218f4aaa9d9bce47cc