### PR TITLE
Use addToCollection when parsing markdown

### DIFF
--- a/src/components/MediaImportExport.tsx
+++ b/src/components/MediaImportExport.tsx
@@ -15,7 +15,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 
 export const MediaImportExport = () => {
-  const { allMedia, importMedia, createCollection, collections } = useMedia();
+  const { allMedia, importMedia, createCollection, collections, addToCollection } = useMedia();
   const [isUploading, setIsUploading] = useState(false);
   const [markdownText, setMarkdownText] = useState("");
   const [showMarkdownImport, setShowMarkdownImport] = useState(false);
@@ -225,7 +225,7 @@ export const MediaImportExport = () => {
             if (mediaItem) {
               const collection = collections.find(c => c.id === currentCollectionId);
               if (collection && !collection.mediaIds.includes(mediaItem.id)) {
-                collection.mediaIds.push(mediaItem.id);
+                addToCollection(collection.id, mediaItem.id);
               }
             }
           }


### PR DESCRIPTION
## Summary
- call `addToCollection` inside `parseMarkdown`
- include `addToCollection` in MediaImportExport context usage

## Testing
- `npm run lint` *(fails: `prefer-const`, `react-hooks/rules-of-hooks`, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6863a7f883888321bcb5f3ae413f0807