### PR TITLE
Fix build failure by ignoring compiled JS artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+src/**/*.js


### PR DESCRIPTION
## Summary
- remove stray compiled `.js` files from builds
- update `.gitignore` to ignore `src/**/*.js`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863bdcd21e08321bb28879691ca90ef