### PR TITLE
Add editable timeline view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { MediaProvider } from "./context/MediaContext";
 import Index from "./pages/Index";
 import MediaDetailPage from "./pages/MediaDetailPage";
+import TimelinePage from "./pages/TimelinePage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -21,6 +22,7 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/media/:id" element={<MediaDetailPage />} />
+            <Route path="/timeline" element={<TimelinePage />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,12 @@ export const Header = () => {
           </Link>
           
           <div className="flex flex-wrap items-center gap-4">
-            <Tabs value={activeFilter} onValueChange={(v) => setActiveFilter(v as any)}>
+            <Tabs
+              value={activeFilter}
+              onValueChange={(v: 'all' | 'movies' | 'tvshows' | 'collections') =>
+                setActiveFilter(v)
+              }
+            >
               <TabsList>
                 <TabsTrigger value="all">All</TabsTrigger>
                 <TabsTrigger value="movies" className="flex items-center gap-1">
@@ -34,7 +39,12 @@ export const Header = () => {
               </TabsList>
             </Tabs>
             
-            <Tabs value={watchStatus} onValueChange={(v) => setWatchStatus(v as any)}>
+            <Tabs
+              value={watchStatus}
+              onValueChange={(v: 'all' | 'watched' | 'unwatched') =>
+                setWatchStatus(v)
+              }
+            >
               <TabsList>
                 <TabsTrigger value="all">All</TabsTrigger>
                 <TabsTrigger value="watched">Watched</TabsTrigger>
@@ -43,9 +53,12 @@ export const Header = () => {
             </Tabs>
           </div>
           
-          <nav>
+          <nav className="flex gap-4">
             <Link to="/" className="text-sm font-medium hover:text-primary transition-colors">
               Home
+            </Link>
+            <Link to="/timeline" className="text-sm font-medium hover:text-primary transition-colors">
+              Timeline
             </Link>
           </nav>
         </div>

--- a/src/components/TimelineGraph.tsx
+++ b/src/components/TimelineGraph.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import ForceGraph3D, { ForceGraph3DInstance } from "3d-force-graph";
+import { AddMediaButton } from "./AddMediaButton";
+import { Button } from "@/components/ui/button";
+import { Trash2 } from "lucide-react";
+import { useMedia } from "../context/MediaContext";
+
+interface GraphNode {
+  id: string;
+  title: string;
+  type: "movie" | "tvshow";
+  val: number;
+}
+
+interface GraphLink {
+  source: string;
+  target: string;
+}
+
+export const TimelineGraph = () => {
+  const { allMedia, deleteMedia } = useMedia();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const graphRef = useRef<ForceGraph3DInstance<GraphNode, GraphLink> | null>(null);
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Clear existing graph
+    if (graphRef.current) {
+      graphRef.current._destructor?.();
+      containerRef.current.innerHTML = "";
+    }
+
+    const graphData = { nodes: [] as GraphNode[], links: [] as GraphLink[] };
+
+    graphData.nodes = allMedia.map(m => ({
+      id: m.id,
+      title: m.title,
+      type: m.type,
+      val: 1,
+    }));
+
+    allMedia.forEach(media => {
+      media.relatedMedia.forEach(rel => {
+        if (!graphData.links.find(l => (l.source === media.id && l.target === rel) || (l.source === rel && l.target === media.id))) {
+          graphData.links.push({ source: media.id, target: rel });
+        }
+      });
+    });
+
+    const Graph = ForceGraph3D()(containerRef.current)
+      .graphData(graphData)
+      .backgroundColor("#0a0b0f")
+      .nodeLabel((node: GraphNode) => node.title)
+      .nodeColor((node: GraphNode) => (node.type === "movie" ? "#6d28d9" : "#ec4899"))
+      .nodeVal((node: GraphNode) => node.val * 10)
+      .linkColor(() => "#6b7280")
+      .linkOpacity(0.5)
+      .onNodeClick((node: GraphNode) => {
+        setSelectedNode(node);
+      });
+
+    Graph.cameraPosition({ z: 200 });
+    graphRef.current = Graph;
+
+    const handleResize = () => {
+      Graph.width(containerRef.current?.clientWidth || window.innerWidth).height(
+        containerRef.current?.clientHeight || window.innerHeight
+      );
+    };
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [allMedia]);
+
+  const handleDelete = () => {
+    if (selectedNode) {
+      deleteMedia(selectedNode.id);
+      setSelectedNode(null);
+    }
+  };
+
+  return (
+    <div className="py-8 px-4 container mx-auto flex flex-col h-[calc(100vh-120px)]">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold">Timeline</h1>
+        <div className="flex gap-2">
+          <AddMediaButton />
+          {selectedNode && (
+            <Button variant="destructive" onClick={handleDelete}>
+              <Trash2 className="h-4 w-4 mr-2" /> Remove Node
+            </Button>
+          )}
+        </div>
+      </div>
+      <div
+        className="flex-1 bg-cinema-dark border border-gray-800 rounded-lg overflow-hidden"
+        ref={containerRef}
+      />
+      {selectedNode && (
+        <div className="mt-4 p-4 bg-cinema-card border border-gray-800 rounded-lg flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-bold">{selectedNode.title}</h2>
+            <p className="text-sm text-muted-foreground capitalize">{selectedNode.type}</p>
+          </div>
+          <Button variant="outline" onClick={() => navigate(`/media/${selectedNode.id}`)}>
+            View Details
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -3,8 +3,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/context/MediaContext.tsx
+++ b/src/context/MediaContext.tsx
@@ -20,6 +20,7 @@ interface MediaContextType {
   toggleWatched: (id: string) => void;
   updateRating: (id: string, rating: number) => void;
   addMedia: (media: Media) => void;
+  deleteMedia: (id: string) => void;
   importMedia: (mediaItems: Media[]) => void;
   clearAllMedia: () => void;
   createCollection: (name: string, image?: string) => Promise<string | undefined>;
@@ -147,6 +148,26 @@ export const MediaProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
     setMedia(prevMedia => [item, ...prevMedia]);
     toast.success(`Added ${newMedia.title} to your library`);
+  };
+
+  const deleteMedia = (id: string) => {
+    setMedia(prev =>
+      prev
+        .filter(item => item.id !== id)
+        .map(item => ({
+          ...item,
+          relatedMedia: item.relatedMedia.filter(rid => rid !== id)
+        }))
+    );
+
+    setCollections(prev =>
+      prev.map(collection => ({
+        ...collection,
+        mediaIds: collection.mediaIds.filter(mid => mid !== id)
+      }))
+    );
+
+    toast.success('Media deleted');
   };
 
   const importMedia = (mediaItems: Media[]) => {
@@ -278,6 +299,7 @@ export const MediaProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         toggleWatched,
         updateRating,
         addMedia,
+        deleteMedia,
         importMedia,
         clearAllMedia,
         createCollection,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,15 +9,23 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Link } from "react-router-dom";
 
 const HomePage = () => {
-  const { filteredMedia, activeFilter, watchStatus, activeCollection, collections, loading } = useMedia();
+  const {
+    filteredMedia,
+    activeFilter,
+    watchStatus,
+    activeCollection,
+    collections,
+    loading,
+    setActiveCollection
+  } = useMedia();
   
   const getTitleText = () => {
-    let typeText = activeFilter === 'movies' ? 'Movies' : 
+    const typeText = activeFilter === 'movies' ? 'Movies' : 
                   activeFilter === 'tvshows' ? 'TV Shows' : 
                   activeFilter === 'collections' ? 'Collections' :
                   'Media';
     
-    let statusText = watchStatus === 'watched' ? 'Watched' : 
+    const statusText = watchStatus === 'watched' ? 'Watched' : 
                     watchStatus === 'unwatched' ? 'To Watch' : 
                     'All';
     
@@ -51,13 +59,15 @@ const HomePage = () => {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {collections.map(collection => (
             <Card key={collection.id} className="overflow-hidden hover:border-primary transition-colors">
-              <Link 
-                to="/" 
+              <Link
+                to="/"
                 onClick={(e) => {
                   e.preventDefault();
-                  activeCollection === collection.id 
-                    ? useMedia().setActiveCollection(null) 
-                    : useMedia().setActiveCollection(collection.id);
+                  if (activeCollection === collection.id) {
+                    setActiveCollection(null);
+                  } else {
+                    setActiveCollection(collection.id);
+                  }
                 }}
                 className="block h-full"
               >

--- a/src/pages/TimelinePage.tsx
+++ b/src/pages/TimelinePage.tsx
@@ -1,0 +1,27 @@
+import { Header } from "../components/Header";
+import { TimelineGraph } from "../components/TimelineGraph";
+import { useMedia } from "../context/MediaContext";
+
+const TimelinePage = () => {
+  const { allMedia } = useMedia();
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 bg-black">
+        {allMedia.length === 0 ? (
+          <div className="flex items-center justify-center h-[50vh] text-center p-4">
+            <div>
+              <h2 className="text-2xl font-bold mb-2">No media to display</h2>
+              <p className="text-muted-foreground">Add some movies or TV shows to build your timeline.</p>
+            </div>
+          </div>
+        ) : (
+          <TimelineGraph />
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default TimelinePage;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -112,5 +113,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add a 3D timeline graph with add/remove node controls
- allow deleting media items from MediaContext
- fix lint issues in UI components and home page
- link new timeline page from header and routing
- use ES module import for Tailwind plugin

## Testing
- `npm run lint -- --fix`

------
https://chatgpt.com/codex/tasks/task_e_6863c78e44808321baf5286058249047